### PR TITLE
Customize Renovate config

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,3 @@
-git_src --branch gardenlinux https://github.com/cyberus-technology/edk2.git
-
 # commit sha from https://github.com/cyberus-technology/edk2/commits/gardenlinux/
 EDK2_COMMIT_SHA="1d892a18e3c6b0e4ead9ab26c9a4f648bbf31476"
 version_increment="1"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices"
+  ],
+  "baseBranchPatterns": [
+    "$default",
+    "/^rel-\\d+$/",
+    "/^sta-\\d+$/"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^prepare_source$/"
+      ],
+      "matchStrings": [
+        "# commit sha from https://github\\.com/cyberus-technology/edk2/commits/(?<currentValue>[^/\\n]+)/\\nEDK2_COMMIT_SHA=\"(?<currentDigest>[a-f0-9]{40})\""
+      ],
+      "depNameTemplate": "cyberus-technology/edk2",
+      "packageNameTemplate": "https://github.com/cyberus-technology/edk2.git",
+      "datasourceTemplate": "git-refs",
+      "versioningTemplate": "loose"
+    }
   ]
 }


### PR DESCRIPTION
- Use `config:best-practices` so the workflow refs are pinned to a digest and tracked
- Add baseBranchPatterns for the `rel-*` and `sta-*` branches
- Add a regex customManager that tracks `EDK2_COMMIT_SHA` in prepare_source against `cyberus-technology/edk2`