### PR TITLE
2150-rel: Remove redundant git_src --branch line

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,3 @@
-git_src --branch gardenlinux https://github.com/cyberus-technology/edk2.git
-
 # commit sha from https://github.com/cyberus-technology/edk2/commits/gardenlinux/
 EDK2_COMMIT_SHA="1d892a18e3c6b0e4ead9ab26c9a4f648bbf31476"
 version_increment="1"


### PR DESCRIPTION
The `git_src --branch` call is redundant when `git_src_commit` pins the exact SHA to check out.